### PR TITLE
Add analytics logger to the build sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ greeter-as.so_SOURCES := ${GREETER_COMMON_SOURCES}
 
 greeter_test_SOURCES := ${GREETER_COMMON_SOURCES} \
                         acr.cpp \
+                        analyticslogger.cpp \
                         base_communication_monitor.cpp \
                         baseresolver.cpp \
                         chronosconnection.cpp \


### PR DESCRIPTION
The pull request https://github.com/Metaswitch/sprout/pull/1585 introduces an analyticslogger.cpp dependency to subscriber_data_manager.cpp, breaking greeter. This PR adds the analyticslogger dependency to the greeter Makefile.