### PR TITLE
Fix makefile to use http_request.cpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ greeter_test_SOURCES := ${GREETER_COMMON_SOURCES} \
                         hssconnection.cpp \
                         http_connection_pool.cpp \
                         httpclient.cpp \
-                        httpconnection.cpp \
+                        http_request.cpp \
                         ifc.cpp \
                         ifchandler.cpp \
                         load_monitor.cpp \


### PR DESCRIPTION
We need to build `httpconnection.cpp` at the moment, because it's pulled in by some of the things the tests pull in.

I think this should be a drop-in replacement, but I need to actually check once Sprout changes are made