### PR TITLE
Adds static_dns_cache.cpp to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ greeter_test_SOURCES := ${GREETER_COMMON_SOURCES} \
                         connection_tracker.cpp \
                         custom_headers.cpp \
                         dnscachedresolver.cpp \
+                        static_dns_cache.cpp \
                         dnsparser.cpp \
                         fakecurl.cpp \
                         fakehssconnection.cpp \


### PR DESCRIPTION
This is needed as it is a new file in cpp-common